### PR TITLE
update arch iso to 2017.01.01

### DIFF
--- a/vagrant/scripts/virtualbox.sh
+++ b/vagrant/scripts/virtualbox.sh
@@ -61,7 +61,9 @@ cat <<-EOF > "${TARGET_DIR}${CONFIG_SCRIPT}"
   set -e
 
 	echo '${FQDN}' > /etc/hostname
-	/usr/bin/ln -s /usr/share/zoneinfo/${TIMEZONE} /etc/localtime
+	if [ ! -e /etc/localtime ]; then
+		/usr/bin/ln -s /usr/share/zoneinfo/${TIMEZONE} /etc/localtime
+	fi
 	/usr/bin/hwclock --systohc --utc
 	echo 'KEYMAP=${KEYMAP}' > /etc/vconsole.conf
 	/usr/bin/sed -i 's/#${LANGUAGE}/${LANGUAGE}/' /etc/locale.gen

--- a/vagrant/scripts/virtualbox.sh
+++ b/vagrant/scripts/virtualbox.sh
@@ -7,7 +7,6 @@ FQDN='blackarch.vm'
 KEYMAP='us'
 LANGUAGE='en_US.UTF-8'
 PASSWORD=$(/usr/bin/openssl passwd -crypt 'vagrant')
-TIMEZONE='UTC'
 Green='\e[0;32m'
 Reset='\e[0m'
 
@@ -61,9 +60,6 @@ cat <<-EOF > "${TARGET_DIR}${CONFIG_SCRIPT}"
   set -e
 
 	echo '${FQDN}' > /etc/hostname
-	if [ ! -e /etc/localtime ]; then
-		/usr/bin/ln -s /usr/share/zoneinfo/${TIMEZONE} /etc/localtime
-	fi
 	/usr/bin/hwclock --systohc --utc
 	echo 'KEYMAP=${KEYMAP}' > /etc/vconsole.conf
 	/usr/bin/sed -i 's/#${LANGUAGE}/${LANGUAGE}/' /etc/locale.gen

--- a/vagrant/template.json
+++ b/vagrant/template.json
@@ -76,9 +76,9 @@
   ],
   "variables": {
     "cpus": "1",
-    "iso_checksum": "b06f015b3f1298671523074fd810f47904eaf4d2329e245be4342bd01ecca082",
+    "iso_checksum": "4d9d67b1a20a3b44b0dd38679400971a68d5bd9f96608bd13a677d84b8a7ece5",
     "iso_checksum_type": "sha256",
-    "iso_url": "http://mirror.rackspace.com/archlinux/iso/2017.01.01/archlinux-2017.01.01-dual.iso",
+    "iso_url": "http://mirror.rackspace.com/archlinux/iso/2017.02.01/archlinux-2017.02.01-dual.iso",
     "memory": "1024"
   }
 }

--- a/vagrant/template.json
+++ b/vagrant/template.json
@@ -76,9 +76,9 @@
   ],
   "variables": {
     "cpus": "1",
-    "iso_checksum": "c0d5b2bd4d01741a770c4229f8b2939eecca8275dc9207cf629d0fa07787160b",
+    "iso_checksum": "b06f015b3f1298671523074fd810f47904eaf4d2329e245be4342bd01ecca082",
     "iso_checksum_type": "sha256",
-    "iso_url": "http://mirror.rackspace.com/archlinux/iso/2016.08.01/archlinux-2016.08.01-dual.iso",
+    "iso_url": "http://mirror.rackspace.com/archlinux/iso/2017.01.01/archlinux-2017.01.01-dual.iso",
     "memory": "1024"
   }
 }


### PR DESCRIPTION
This is necessary as the rackspace mirror no longer
provides the archlinux-2016.08.01-dual.iso

Signed-off-by: Stefan Venz <stefan.venz@protonmail.com>