### PR TITLE
export gnupghome

### DIFF
--- a/vagrant/scripts/blackarch.sh
+++ b/vagrant/scripts/blackarch.sh
@@ -5,6 +5,7 @@ set -e
 TERM=${TERM:-xterm}
 export TERM
 
+export GNUPGHOME=${HOME}/.gnupg/
 curl https://www.blackarch.org/strap.sh | bash
 NUMPKGS=$(/usr/bin/yaourt -Ss blackarch | /usr/bin/grep -v "^    " | /usr/bin/wc -l)
 echo "$NUMPKGS" BlackArch packages available.


### PR DESCRIPTION
Vagrant Box creation ran into BlackArch/blackarch#1047 occasionally
To avoid this export GNUPGHOME as mentioned in the issue

Signed-off-by: Stefan Venz <stefan.venz@protonmail.com>