### PR TITLE
Add sed and tar dependency installation to blackarch-builder Docker…

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM base/archlinux
 RUN pacman --noconfirm -Sy archlinux-keyring && \
-    pacman --noconfirm -S expect arch-install-scripts && \
+    pacman --noconfirm -S expect sed tar arch-install-scripts && \
     pacman -Scc
 ADD ./build.sh /usr/local/bin
 ADD ./build-helper.sh /usr/local/bin


### PR DESCRIPTION
Building blackarcher-builder from base/archlinux is failing when running build.sh because sed and tar are absent.