### PR TITLE
Remove NetworkManager from base box

### DIFF
--- a/vagrant/scripts/networkmanager.sh
+++ b/vagrant/scripts/networkmanager.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-
-/usr/bin/pacman -Sy --noconfirm networkmanager
-/usr/bin/systemctl enable NetworkManager.service

--- a/vagrant/template.json
+++ b/vagrant/template.json
@@ -66,7 +66,6 @@
         "scripts/yaourt.sh",
         "scripts/zsh.sh",
         "scripts/vagrant.sh",
-        "scripts/networkmanager.sh",
         "scripts/blackarch.sh",
         "scripts/cleanup.sh",
         "scripts/zerodisk.sh"


### PR DESCRIPTION
The NetworkManager is not needed initially and can cause some hick ups.

If your VM is connected to a DHCP Network and will receive a lease and the NM will assign
the address to eth1. If you set up your Vagrantfile with a static ip for public network your eth1 interface
will receive a second ip via netctl.
So your VM will show up twice in the network, once with your assigned ip and again with its dhcp lease.

As the NM is just nice to have and not needed i would remove it from the base box

Best regards
ikstream

Signed-off-by: Stefan Venz <stefan.venz@protonmail.com>