### PR TITLE
Fixing the docker creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-docker/output
+docker/output/*
+!docker/output/build-helper.sh
+!docker/output/build-pacman.conf
+!docker/output/build.sh
 
 vagrant/vagrant_cache
 vagrant/output*

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ ADD ./build.sh /usr/local/bin
 ADD ./build-helper.sh /usr/local/bin
 ADD ./build-pacman.conf /usr/local/etc
 ADD https://www.blackarch.org/strap.sh /usr/local/bin
-RUN chmod u+x usr/local/bin/strap.sh
+RUN chmod u+x /usr/local/bin/strap.sh
 VOLUME ["/output"]
 WORKDIR /output
 ENTRYPOINT ["/usr/local/bin/build.sh"]

--- a/docker/output/build-helper.sh
+++ b/docker/output/build-helper.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+rm -r /usr/share/man/*
+haveged -w 1024
+pacman-key --init
+pkill haveged
+pacman -Rs --noconfirm haveged
+pacman-key --populate ARCH_KEYRING
+pkill gpg-agent
+ln -s /usr/share/zoneinfo/UTC /etc/localtime
+echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen
+locale-gen
+update-ca-trust
+pacman-db-upgrade

--- a/docker/output/build-pacman.conf
+++ b/docker/output/build-pacman.conf
@@ -1,0 +1,92 @@
+#
+# /etc/pacman.conf
+#
+# See the pacman.conf(5) manpage for option and repository directives
+
+#
+# GENERAL OPTIONS
+#
+[options]
+# The following paths are commented out with their default values listed.
+# If you wish to use different paths, uncomment and update the paths.
+#RootDir     = /
+#DBPath      = /var/lib/pacman/
+#CacheDir    = /var/cache/pacman/pkg/
+#LogFile     = /var/log/pacman.log
+#GPGDir      = /etc/pacman.d/gnupg/
+HoldPkg     = pacman glibc
+#XferCommand = /usr/bin/curl -C - -f %u > %o
+#XferCommand = /usr/bin/wget --passive-ftp -c -O %o %u
+#CleanMethod = KeepInstalled
+#UseDelta    = 0.7
+Architecture = auto
+
+# Pacman won't upgrade packages listed in IgnorePkg and members of IgnoreGroup
+#IgnorePkg   =
+#IgnoreGroup =
+
+#NoUpgrade   =
+#NoExtract   =
+
+# Misc options
+#UseSyslog
+#Color
+#TotalDownload
+# We cannot check disk space from within a chroot environment
+#CheckSpace
+#VerbosePkgLists
+
+# By default, pacman accepts packages signed by keys that its local keyring
+# trusts (see pacman-key and its man page), as well as unsigned packages.
+SigLevel    = Required DatabaseOptional
+LocalFileSigLevel = Optional
+#RemoteFileSigLevel = Required
+
+# NOTE: You must run `pacman-key --init` before first using pacman; the local
+# keyring can then be populated with the keys of all official Arch Linux
+# packagers with `pacman-key --populate archlinux`.
+
+#
+# REPOSITORIES
+#   - can be defined here or included from another file
+#   - pacman will search repositories in the order defined here
+#   - local/custom mirrors can be added here or in separate files
+#   - repositories listed first will take precedence when packages
+#     have identical names, regardless of version number
+#   - URLs will have $repo replaced by the name of the current repo
+#   - URLs will have $arch replaced by the name of the architecture
+#
+# Repository entries are of the format:
+#       [repo-name]
+#       Server = ServerName
+#       Include = IncludePath
+#
+# The header [repo-name] is crucial - it must be present and
+# uncommented to enable the repo.
+#
+
+# The testing repositories are disabled by default. To enable, uncomment the
+# repo name header and Include lines. You can add preferred servers immediately
+# after the header, and they will be used before the default mirrors.
+
+#[testing]
+#Include = /etc/pacman.d/mirrorlist
+
+[core]
+Include = /etc/pacman.d/mirrorlist
+
+[extra]
+Include = /etc/pacman.d/mirrorlist
+
+#[community-testing]
+#Include = /etc/pacman.d/mirrorlist
+
+[community]
+Include = /etc/pacman.d/mirrorlist
+
+# An example of a custom package repository.  See the pacman manpage for
+# tips on creating your own repositories.
+#[custom]
+#SigLevel = Optional TrustAll
+#Server = file:///home/custompkgs
+

--- a/docker/output/build.sh
+++ b/docker/output/build.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+
+# build.sh -
+
+# Adapted from
+# https://github.com/docker/docker/commit/4137a0ea327ea1775c1b57892fd684da2c738f3e
+# Generate a minimal filesystem for BlackArch and load it into the local
+# docker as "blackarch".
+# requires root
+
+set -e
+
+TERM=${TERM:-xterm}
+export TERM
+
+# simple error message wrapper
+err()
+{
+    echo >&2 `tput bold; tput setaf 1`"[-] ERROR: ${*}"`tput sgr0`
+    exit 1337
+}
+
+# simple warning message wrapper
+warn()
+{
+    echo >&2 `tput bold; tput setaf 1`"[!] WARNING: ${*}"`tput sgr0`
+}
+
+# simple echo wrapper
+msg()
+{
+    echo `tput bold; tput setaf 2`"[+] ${*}"`tput sgr0`
+}
+
+msg 'checking requirements'
+REQUIREMENTS="pacstrap expect curl"
+for req in $REQUIREMENTS ; do
+	hash $req &>/dev/null || {
+		echo "Could not find $req."
+	  exit 1
+  }
+done
+
+export LANG="C.UTF-8"
+
+ROOTFS=$(mktemp -d $PWD/rootfs-blackarch-XXXXXXXXXXX)
+chmod 755 $ROOTFS
+
+# packages to ignore for space savings
+PKGIGNORE=(
+    cryptsetup
+    device-mapper
+    dhcpcd
+    iproute2
+    jfsutils
+    linux
+    lvm2
+    man-db
+    man-pages
+    mdadm
+    nano
+    netctl
+    openresolv
+    pciutils
+    pcmciautils
+    reiserfsprogs
+    s-nail
+    systemd-sysvcompat
+    usbutils
+    vi
+    xfsprogs
+)
+IFS=','
+PKGIGNORE="${PKGIGNORE[*]}"
+unset IFS
+
+PACMAN_CONF=($PWD/build-pacman.conf)
+PACMAN_MIRRORLIST='Server = https://mirrors.kernel.org/archlinux/$repo/os/$arch'
+PACMAN_EXTRA_PKGS=''
+EXPECT_TIMEOUT=360
+ARCH_KEYRING=archlinux
+DOCKER_IMAGE_NAME=blackarch
+
+export PACMAN_MIRRORLIST
+
+msg 'pacstrapping minimal arch installation'
+
+expect <<EOF
+	set send_slow {1 .1}
+	proc send {ignore arg} {
+		sleep .1
+		exp_send -s -- \$arg
+	}
+	set timeout $EXPECT_TIMEOUT
+
+	spawn pacstrap -C $PACMAN_CONF -c -d -G -i $ROOTFS base ca-certificates haveged libtool $PACMAN_EXTRA_PKGS --ignore $PKGIGNORE
+	expect {
+		-exact "anyway? \[Y/n\] " { send -- "n\r"; exp_continue }
+		-exact "(default=all): " { send -- "\r"; exp_continue }
+		-exact "installation? \[Y/n\]" { send -- "y\r"; exp_continue }
+	}
+EOF
+
+msg 'injecting and running config helper script'
+cp -vf $PWD/build-helper.sh $ROOTFS/bin/build-helper.sh
+sed -i 's/ARCH_KEYRING/'$ARCH_KEYRING'/g' $ROOTFS/bin/build-helper.sh
+echo $PACMAN_MIRRORLIST > $ROOTFS/etc/pacman.d/mirrorlist
+arch-chroot $ROOTFS /bin/build-helper.sh
+rm -v $ROOTFS/bin/build-helper.sh
+
+msg 'bootstrapping BlackArch keys and repos'
+curl -O https://blackarch.org/strap.sh
+chmod +x $PWD/strap.sh
+mv -v $PWD/strap.sh $ROOTFS/bin/strap.sh
+arch-chroot $ROOTFS pacman-key --populate; pacman-key --update
+arch-chroot $ROOTFS ./bin/strap.sh
+
+msg 'creating device nodes'
+# udev doesn't work in containers, rebuild /dev
+DEV=$ROOTFS/dev
+rm -rf $DEV
+mkdir -p $DEV
+mknod -m 666 $DEV/null c 1 3
+mknod -m 666 $DEV/zero c 1 5
+mknod -m 666 $DEV/random c 1 8
+mknod -m 666 $DEV/urandom c 1 9
+mkdir -m 755 $DEV/pts
+mkdir -m 1777 $DEV/shm
+mknod -m 666 $DEV/tty c 5 0
+mknod -m 600 $DEV/console c 5 1
+mknod -m 666 $DEV/tty0 c 4 0
+mknod -m 666 $DEV/full c 1 7
+mknod -m 600 $DEV/initctl p
+mknod -m 666 $DEV/ptmx c 5 2
+ln -sf /proc/self/fd $DEV/fd
+
+msg 'importing finished image into docker daemon'
+pacman --noconfirm -S docker
+tar --numeric-owner --xattrs --acls -C $ROOTFS -c . > $DOCKER_IMAGE_NAME.tar
+docker import - $DOCKER_IMAGE_NAME < $DOCKER_IMAGE_NAME.tar
+docker run --rm -t $DOCKER_IMAGE_NAME echo Success.
+rm -rf $ROOTFS


### PR DESCRIPTION
When simply cloning the repo and running make, the build crashes in multiple locations. Most of which had to do with mismatched paths. By setting up the file structure as it is now, make should work right away. The output folder is still ignored, except for the shared files needed during the building process. 
I also fixed a path in the Docker file that caused chmod to fail.

To verify, simply clone a fresh repo and try make in the docker folder.