### PR TITLE
adding multilib for x32 dependencies

### DIFF
--- a/docker/build-pacman.conf
+++ b/docker/build-pacman.conf
@@ -78,6 +78,9 @@ Include = /etc/pacman.d/mirrorlist
 [extra]
 Include = /etc/pacman.d/mirrorlist
 
+[multilib]
+Include = /etc/pacman.d/mirrorlist
+
 #[community-testing]
 #Include = /etc/pacman.d/mirrorlist
 


### PR DESCRIPTION
When you install blackarch, you will have a problem dependencies for some packages (Ex :Veil) , dependencies like wine , lib32 .... 
So for that I just added multilab.  