### PR TITLE
Update to build.sh

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -95,7 +95,7 @@ unset IFS
 
 PACMAN_CONF=(/usr/local/etc/build-pacman.conf)
 PACMAN_MIRRORLIST='Server = https://mirrors.kernel.org/archlinux/$repo/os/$arch'
-PACMAN_EXTRA_PKGS='sed pacman procps-ng'
+PACMAN_EXTRA_PKGS='sed pacman procps-ng base-devel'
 EXPECT_TIMEOUT=360
 ARCH_KEYRING=archlinux
 DOCKER_IMAGE_NAME=blackarch

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -117,6 +117,7 @@ expect <<EOF
 		-exact "anyway? \[Y/n\] " { send -- "n\r"; exp_continue }
 		-exact "(default=all): " { send -- "\r"; exp_continue }
 		-exact "installation? \[Y/n\]" { send -- "y\r"; exp_continue }
+		-exact "upgrade? \[y/N\]" { send -- "Y\r"; exp_continue }
 	}
 EOF
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -95,7 +95,7 @@ unset IFS
 
 PACMAN_CONF=(/usr/local/etc/build-pacman.conf)
 PACMAN_MIRRORLIST='Server = https://mirrors.kernel.org/archlinux/$repo/os/$arch'
-PACMAN_EXTRA_PKGS=''
+PACMAN_EXTRA_PKGS='sed pacman procps-ng'
 EXPECT_TIMEOUT=360
 ARCH_KEYRING=archlinux
 DOCKER_IMAGE_NAME=blackarch


### PR DESCRIPTION
1) An additional -exact entry is required for a prompt that states "Do you want to skip the above package for this upgrade? [y/N]" to supply the answer with a "Y". The "... above package ..." here refers to the ones in $PKGIGNORE.

2) sed, pacman and procps-ng need to be installed during pacstrap as they are required by build-helper.sh script but do not get installed otherwise. Therefore, adding them to $PACMAN_EXTRA_PKGS.

3) base-devel is recommended to be installed in the image as per required by pkgbuild scripts of some tools. Eg, whatweb.