### PR TITLE
Update build.sh

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -129,7 +129,6 @@ arch-chroot $ROOTFS /bin/build-helper.sh
 rm -v $ROOTFS/bin/build-helper.sh
 
 msg 'bootstrapping BlackArch keys and repos'
-curl -O https://blackarch.org/strap.sh
 chmod +x /usr/local/bin/strap.sh
 mv -v /usr/local/bin/strap.sh $ROOTFS/bin/strap.sh
 arch-chroot $ROOTFS pacman-key --populate; pacman-key --update


### PR DESCRIPTION
Blackarch's strap.sh is being curled which isn't required as the strap.sh script is already being added in the Dockerfile to the /usr/local/bin/strap.sh and the same is being moved to the $ROOTFS/bin/strap.sh. The one being curled isn't being used at all.